### PR TITLE
Add ability to replace JSON.stringify

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ require('console.json')(null, 4);
 For exact meaning of these two arguments, see
 [JSON.stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
 
+You can pass a function as a third argument to be used instead of `JSON.stringify`
+
+```js
+function jsonAngleBrackets(value, replacer, space) {
+  var result = JSON.stringify(value, replacer, space);
+  return '<' + result + '>';
+}
+require('console.json')(null, 4, jsonAngleBrackets);
+// Surrounds objects and arrays with angle brackets
+```
+
 ### Small print
 
 Author: Gleb Bahmutov &copy; 2014

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 (function init(root) {
 
 
-  function consoleJson(replacer, space) {
+  function consoleJson(replacer, space, jsonStringify) {
     if (typeof replacer === 'number') {
       space = replacer;
       replacer = null;
@@ -12,11 +12,14 @@
     if (typeof space === 'undefined') {
       space = 2;
     }
+    if (typeof jsonStringify !== 'function') {
+      jsonStringify = JSON.stringify.bind(JSON);
+    }
 
-    setConsoleJson(replacer, space);
+    setConsoleJson(replacer, space, jsonStringify);
   }
 
-  function setConsoleJson(replacer, space) {
+  function setConsoleJson(replacer, space, jsonStringify) {
     if (typeof space === 'number') {
       console.assert(space >= 0, 'invalid space number ' + space);
     } else if (typeof space !== 'string') {
@@ -27,7 +30,7 @@
       var args = Array.prototype.slice.call(arguments);
       args = args.map(function (k) {
         if (typeof k === 'object' || Array.isArray(k)) {
-          return JSON.stringify(k, replacer, space);
+          return jsonStringify(k, replacer, space);
         }
         return k;
       });
@@ -35,7 +38,7 @@
     };
   }
 
-  setConsoleJson(null, 2);
+  setConsoleJson(null, 2, JSON.stringify.bind(JSON));
 
   if (typeof module !== 'undefined') {
     module.exports = consoleJson;

--- a/test/test.js
+++ b/test/test.js
@@ -17,3 +17,11 @@ console.json('foo with 4 spaces', foo);
 delete console.json;
 require('..')(null, '**');
 console.json('foo with **\n', foo);
+
+delete console.json;
+function jsonStringify(value, replacer, space) {
+  var result = JSON.stringify(value, replacer, space);
+  return 'JSON: ' + result;
+}
+require('..')(null, 4, jsonStringify);
+console.json('foo with custom stringify', foo);


### PR DESCRIPTION
Hello!

This pull request adds an optional third argument, which is a function that will be called instead of `JSON.stringify`.

I'm writing [a tool](https://github.com/daxelrod/jowl) which will use console.json, but I also want to add colors to the output JSON for syntax highlighting. I would like to be able to call `console.json` with a custom function that stringifies the JSON and then adds ANSI color codes. This seems to be the best approach because there's no good way to capture the output after it's gone to console.log.

Please let me know if you'd like me to change anything about the documentation, implementation, or tests. I have manually verified that the test output looks correct, but it doesn't look like there's anything in the tests themselves that automatically verifies the correctness of the output.

Thank you for writing console.json, it is exactly the module I thought I would have to write before I found you had already done it. :smile: 
